### PR TITLE
Add additional extensions for jpeg files

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 
 func doIt(inputDirectory string, outputDirectory string, cfg config) {
 
-	result := util.ListFiles(inputDirectory, util.IsFileWithExtension([]string{".jpg"}))
+	result := util.ListFiles(inputDirectory, util.IsFileWithExtension([]string{".jpg", ".jpeg", ".jfif", ".pjpeg", ".pjp"}))
 
 	for _, file := range result {
 


### PR DESCRIPTION
Support usual extensions for jpeg format
Source https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types

Fixes #12